### PR TITLE
Nodes are only interactive when enabled, fixing large mesh performance issues; UI updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@universalviewer/aleph",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@universalviewer/aleph",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Aleph",
   "main": "dist/index.js",
   "module": "dist/index.mjs",

--- a/src/components.d.ts
+++ b/src/components.d.ts
@@ -75,9 +75,17 @@ export namespace Components {
   interface AlGraphEditor {
     'angles': Map<string, AlAngle> | null;
     'edges': Map<string, AlEdge> | null;
+    'graphEnabled': boolean;
+    'graphVisible': boolean;
     'node': [string, AlNode];
     'nodes': Map<string, AlNode> | null;
     'selected': string | null;
+    'units': Units;
+  }
+  interface AlGraphSettings {
+    'graphEnabled': boolean;
+    'graphVisible': boolean;
+    'units': Units;
   }
   interface AlNodeEditor {
     'node': [string, AlNode];
@@ -87,17 +95,12 @@ export namespace Components {
     'selected': string | null;
   }
   interface AlSettings {
-    'boundingBoxEnabled': boolean;
-    'controlsType': ControlsType;
     'displayMode': DisplayMode;
-    'graphEnabled': boolean;
-    'graphVisible': boolean;
     'orientation': Orientation;
     'slicesBrightness': number;
     'slicesContrast': number;
     'slicesIndex': number;
     'slicesMaxIndex': number;
-    'units': Units;
     'volumeBrightness': number;
     'volumeContrast': number;
     'volumeSteps': number;
@@ -122,6 +125,10 @@ export namespace Components {
   interface AlUrlPicker {
     'url': string | null;
     'urls': Map<string, string> | null;
+  }
+  interface AlViewControls {
+    'boundingBoxEnabled': boolean;
+    'controlsType': ControlsType;
   }
   interface AlViewer {
     'clearGraph': () => Promise<void>;
@@ -190,6 +197,12 @@ declare global {
     new (): HTMLAlGraphEditorElement;
   };
 
+  interface HTMLAlGraphSettingsElement extends Components.AlGraphSettings, HTMLStencilElement {}
+  var HTMLAlGraphSettingsElement: {
+    prototype: HTMLAlGraphSettingsElement;
+    new (): HTMLAlGraphSettingsElement;
+  };
+
   interface HTMLAlNodeEditorElement extends Components.AlNodeEditor, HTMLStencilElement {}
   var HTMLAlNodeEditorElement: {
     prototype: HTMLAlNodeEditorElement;
@@ -220,6 +233,12 @@ declare global {
     new (): HTMLAlUrlPickerElement;
   };
 
+  interface HTMLAlViewControlsElement extends Components.AlViewControls, HTMLStencilElement {}
+  var HTMLAlViewControlsElement: {
+    prototype: HTMLAlViewControlsElement;
+    new (): HTMLAlViewControlsElement;
+  };
+
   interface HTMLAlViewerElement extends Components.AlViewer, HTMLStencilElement {}
   var HTMLAlViewerElement: {
     prototype: HTMLAlViewerElement;
@@ -231,11 +250,13 @@ declare global {
     'al-control-panel': HTMLAlControlPanelElement;
     'al-edge-editor': HTMLAlEdgeEditorElement;
     'al-graph-editor': HTMLAlGraphEditorElement;
+    'al-graph-settings': HTMLAlGraphSettingsElement;
     'al-node-editor': HTMLAlNodeEditorElement;
     'al-node-list': HTMLAlNodeListElement;
     'al-settings': HTMLAlSettingsElement;
     'al-tabs': HTMLAlTabsElement;
     'al-url-picker': HTMLAlUrlPickerElement;
+    'al-view-controls': HTMLAlViewControlsElement;
     'al-viewer': HTMLAlViewerElement;
   }
 }
@@ -286,9 +307,19 @@ declare namespace LocalJSX {
   interface AlGraphEditor extends JSXBase.HTMLAttributes<HTMLAlGraphEditorElement> {
     'angles'?: Map<string, AlAngle> | null;
     'edges'?: Map<string, AlEdge> | null;
+    'graphEnabled'?: boolean;
+    'graphVisible'?: boolean;
     'node'?: [string, AlNode];
     'nodes'?: Map<string, AlNode> | null;
     'selected'?: string | null;
+    'units'?: Units;
+  }
+  interface AlGraphSettings extends JSXBase.HTMLAttributes<HTMLAlGraphSettingsElement> {
+    'graphEnabled'?: boolean;
+    'graphVisible'?: boolean;
+    'onGraphEnabledChanged'?: (event: CustomEvent<any>) => void;
+    'onUnitsChanged'?: (event: CustomEvent<any>) => void;
+    'units'?: Units;
   }
   interface AlNodeEditor extends JSXBase.HTMLAttributes<HTMLAlNodeEditorElement> {
     'node'?: [string, AlNode];
@@ -301,21 +332,12 @@ declare namespace LocalJSX {
     'selected'?: string | null;
   }
   interface AlSettings extends JSXBase.HTMLAttributes<HTMLAlSettingsElement> {
-    'boundingBoxEnabled'?: boolean;
-    'controlsType'?: ControlsType;
     'displayMode'?: DisplayMode;
-    'graphEnabled'?: boolean;
-    'graphVisible'?: boolean;
-    'onBoundingBoxEnabledChanged'?: (event: CustomEvent<any>) => void;
-    'onControlsTypeChanged'?: (event: CustomEvent<any>) => void;
     'onDisplayModeChanged'?: (event: CustomEvent<any>) => void;
-    'onGraphEnabledChanged'?: (event: CustomEvent<any>) => void;
     'onOrientationChanged'?: (event: CustomEvent<any>) => void;
-    'onRecenter'?: (event: CustomEvent<any>) => void;
     'onSlicesBrightnessChanged'?: (event: CustomEvent<any>) => void;
     'onSlicesContrastChanged'?: (event: CustomEvent<any>) => void;
     'onSlicesIndexChanged'?: (event: CustomEvent<any>) => void;
-    'onUnitsChanged'?: (event: CustomEvent<any>) => void;
     'onVolumeBrightnessChanged'?: (event: CustomEvent<any>) => void;
     'onVolumeContrastChanged'?: (event: CustomEvent<any>) => void;
     'onVolumeStepsChanged'?: (event: CustomEvent<any>) => void;
@@ -325,7 +347,6 @@ declare namespace LocalJSX {
     'slicesContrast'?: number;
     'slicesIndex'?: number;
     'slicesMaxIndex'?: number;
-    'units'?: Units;
     'volumeBrightness'?: number;
     'volumeContrast'?: number;
     'volumeSteps'?: number;
@@ -350,6 +371,13 @@ declare namespace LocalJSX {
     'url'?: string | null;
     'urls'?: Map<string, string> | null;
   }
+  interface AlViewControls extends JSXBase.HTMLAttributes<HTMLAlViewControlsElement> {
+    'boundingBoxEnabled'?: boolean;
+    'controlsType'?: ControlsType;
+    'onBoundingBoxEnabledChanged'?: (event: CustomEvent<any>) => void;
+    'onControlsTypeChanged'?: (event: CustomEvent<any>) => void;
+    'onRecenter'?: (event: CustomEvent<any>) => void;
+  }
   interface AlViewer extends JSXBase.HTMLAttributes<HTMLAlViewerElement> {
     'dracoDecoderPath'?: string | null;
     'envMapPath'?: string | null;
@@ -371,11 +399,13 @@ declare namespace LocalJSX {
     'al-control-panel': AlControlPanel;
     'al-edge-editor': AlEdgeEditor;
     'al-graph-editor': AlGraphEditor;
+    'al-graph-settings': AlGraphSettings;
     'al-node-editor': AlNodeEditor;
     'al-node-list': AlNodeList;
     'al-settings': AlSettings;
     'al-tabs': AlTabs;
     'al-url-picker': AlUrlPicker;
+    'al-view-controls': AlViewControls;
     'al-viewer': AlViewer;
   }
 }

--- a/src/components/al-angle-editor/readme.md
+++ b/src/components/al-angle-editor/readme.md
@@ -24,7 +24,7 @@
 
 ### Used by
 
- - [al-graph-editor](..\al-graph-editor)
+ - [al-graph-editor](../al-graph-editor)
 
 ### Depends on
 

--- a/src/components/al-console/readme.md
+++ b/src/components/al-console/readme.md
@@ -24,7 +24,7 @@
 
 ### Used by
 
- - [al-control-panel](..\al-control-panel)
+ - [al-control-panel](../al-control-panel)
 
 ### Depends on
 

--- a/src/components/al-control-panel/al-control-panel.tsx
+++ b/src/components/al-control-panel/al-control-panel.tsx
@@ -109,18 +109,22 @@ export class AlSettings {
           ) : null}
           {this.srcTabEnabled ? (
             <ion-tab tab="src">
+              <al-view-controls
+                bounding-box-enabled={this.boundingBoxEnabled}
+                controls-type={this.controlsType}
+              ></al-view-controls>
               <al-url-picker urls={this.urls} url={this.url}></al-url-picker>
             </ion-tab>
           ) : null}
           {this.settingsTabEnabled ? (
             <ion-tab tab="settings">
               <Scroll height={tabContentHeight}>
-                <al-settings
+                <al-view-controls
                   bounding-box-enabled={this.boundingBoxEnabled}
                   controls-type={this.controlsType}
+                ></al-view-controls>
+                <al-settings
                   display-mode={this.displayMode}
-                  graph-enabled={this.graphEnabled}
-                  graph-visible={this.graphTabEnabled}
                   orientation={this.orientation}
                   slices-index={this.slicesIndex}
                   slices-max-index={this.slicesMaxIndex}
@@ -130,7 +134,6 @@ export class AlSettings {
                   volume-contrast={this.volumeContrast}
                   volume-steps={this.volumeSteps}
                   volume-steps-high-enabled={this.volumeStepsHighEnabled}
-                  units={this.units}
                 ></al-settings>
               </Scroll>
             </ion-tab>
@@ -138,11 +141,18 @@ export class AlSettings {
           {this.graphTabEnabled ? (
             <ion-tab tab="graph">
               <Scroll height={tabContentHeight}>
+                <al-view-controls
+                  bounding-box-enabled={this.boundingBoxEnabled}
+                  controls-type={this.controlsType}
+                ></al-view-controls>
                 <al-graph-editor
                   selected={this.selected}
                   nodes={this.nodes}
                   angles={this.angles}
                   edges={this.edges}
+                  graph-enabled={this.graphEnabled}
+                  graph-visible={this.graphTabEnabled}
+                  units={this.units}
                 ></al-graph-editor>
               </Scroll>
             </ion-tab>
@@ -150,6 +160,10 @@ export class AlSettings {
           {this.consoleTabEnabled ? (
             <ion-tab tab="console">
               <Scroll height={tabContentHeight}>
+                <al-view-controls
+                  bounding-box-enabled={this.boundingBoxEnabled}
+                  controls-type={this.controlsType}
+                ></al-view-controls>
                 <al-console graph={this._getGraphJson()}></al-console>
               </Scroll>
             </ion-tab>

--- a/src/components/al-control-panel/readme.md
+++ b/src/components/al-control-panel/readme.md
@@ -41,16 +41,17 @@
 ### Depends on
 
 - ion-app
-- [al-tabs](..\al-tabs)
+- [al-tabs](../al-tabs)
 - ion-tab-bar
 - ion-tab-button
 - ion-icon
 - ion-label
 - ion-tab
-- [al-url-picker](..\al-url-picker)
-- [al-settings](..\al-settings)
-- [al-graph-editor](..\al-graph-editor)
-- [al-console](..\al-console)
+- [al-view-controls](../al-view-controls)
+- [al-url-picker](../al-url-picker)
+- [al-settings](../al-settings)
+- [al-graph-editor](../al-graph-editor)
+- [al-console](../al-console)
 
 ### Graph
 ```mermaid
@@ -62,11 +63,15 @@ graph TD;
   al-control-panel --> ion-icon
   al-control-panel --> ion-label
   al-control-panel --> ion-tab
+  al-control-panel --> al-view-controls
   al-control-panel --> al-url-picker
   al-control-panel --> al-settings
   al-control-panel --> al-graph-editor
   al-control-panel --> al-console
   ion-tab-button --> ion-ripple-effect
+  al-view-controls --> ion-button
+  al-view-controls --> ion-icon
+  ion-button --> ion-ripple-effect
   al-url-picker --> ion-item
   al-url-picker --> ion-select
   al-url-picker --> ion-select-option
@@ -75,18 +80,19 @@ graph TD;
   al-url-picker --> ion-icon
   ion-item --> ion-icon
   ion-item --> ion-ripple-effect
-  ion-button --> ion-ripple-effect
-  al-settings --> ion-button
-  al-settings --> ion-icon
   al-settings --> ion-item
-  al-settings --> ion-list-header
+  al-settings --> ion-icon
   al-settings --> ion-toggle
   al-settings --> ion-range
+  al-settings --> ion-list-header
+  al-graph-editor --> al-graph-settings
   al-graph-editor --> al-node-list
   al-graph-editor --> ion-item-divider
   al-graph-editor --> al-node-editor
   al-graph-editor --> al-edge-editor
   al-graph-editor --> al-angle-editor
+  al-graph-settings --> ion-item
+  al-graph-settings --> ion-toggle
   al-node-list --> ion-list
   al-node-list --> ion-item
   al-node-editor --> ion-item

--- a/src/components/al-edge-editor/readme.md
+++ b/src/components/al-edge-editor/readme.md
@@ -24,7 +24,7 @@
 
 ### Used by
 
- - [al-graph-editor](..\al-graph-editor)
+ - [al-graph-editor](../al-graph-editor)
 
 ### Depends on
 

--- a/src/components/al-graph-editor/al-graph-editor.tsx
+++ b/src/components/al-graph-editor/al-graph-editor.tsx
@@ -1,5 +1,6 @@
 import { Component, h, Prop } from "@stencil/core";
 import { AlAngle, AlEdge, AlNode } from "../../interfaces";
+import { Units } from "../../enums";
 
 @Component({
   tag: "al-graph-editor",
@@ -12,6 +13,9 @@ export class AlGraphEditor {
   @Prop({ mutable: true }) public angles: Map<string, AlAngle> | null = null;
   @Prop({ mutable: true }) public edges: Map<string, AlEdge> | null = null;
   @Prop({ mutable: true }) public selected: string | null = null;
+  @Prop({ mutable: true }) public graphEnabled: boolean;
+  @Prop({ mutable: true }) public graphVisible: boolean;
+  @Prop({ mutable: true }) public units: Units;
 
   private _getSelectedNode(): [string, AlNode] | null {
     if (this.selected && this.nodes) {
@@ -45,6 +49,11 @@ export class AlGraphEditor {
 
   public render() {
     return [
+      <al-graph-settings
+        graph-enabled={this.graphEnabled}
+        graph-visible={this.graphVisible}
+        units={this.units}
+      ></al-graph-settings>,
       <al-node-list nodes={this.nodes} selected={this.selected}></al-node-list>,
       <ion-item-divider></ion-item-divider>,
       <al-node-editor node={this._getSelectedNode()}></al-node-editor>,

--- a/src/components/al-graph-editor/readme.md
+++ b/src/components/al-graph-editor/readme.md
@@ -7,41 +7,48 @@
 
 ## Properties
 
-| Property   | Attribute  | Description | Type                   | Default     |
-| ---------- | ---------- | ----------- | ---------------------- | ----------- |
-| `angles`   | --         |             | `Map<string, AlAngle>` | `null`      |
-| `edges`    | --         |             | `Map<string, AlEdge>`  | `null`      |
-| `node`     | --         |             | `[string, AlNode]`     | `undefined` |
-| `nodes`    | --         |             | `Map<string, AlNode>`  | `null`      |
-| `selected` | `selected` |             | `string`               | `null`      |
+| Property       | Attribute       | Description | Type                                | Default     |
+| -------------- | --------------- | ----------- | ----------------------------------- | ----------- |
+| `angles`       | --              |             | `Map<string, AlAngle>`              | `null`      |
+| `edges`        | --              |             | `Map<string, AlEdge>`               | `null`      |
+| `graphEnabled` | `graph-enabled` |             | `boolean`                           | `undefined` |
+| `graphVisible` | `graph-visible` |             | `boolean`                           | `undefined` |
+| `node`         | --              |             | `[string, AlNode]`                  | `undefined` |
+| `nodes`        | --              |             | `Map<string, AlNode>`               | `null`      |
+| `selected`     | `selected`      |             | `string`                            | `null`      |
+| `units`        | `units`         |             | `Units.METERS \| Units.MILLIMETERS` | `undefined` |
 
 
 ## Dependencies
 
 ### Used by
 
- - [al-control-panel](..\al-control-panel)
+ - [al-control-panel](../al-control-panel)
 
 ### Depends on
 
-- [al-node-list](..\al-node-list)
+- [al-graph-settings](../al-graph-settings)
+- [al-node-list](../al-node-list)
 - ion-item-divider
-- [al-node-editor](..\al-node-editor)
-- [al-edge-editor](..\al-edge-editor)
-- [al-angle-editor](..\al-angle-editor)
+- [al-node-editor](../al-node-editor)
+- [al-edge-editor](../al-edge-editor)
+- [al-angle-editor](../al-angle-editor)
 
 ### Graph
 ```mermaid
 graph TD;
+  al-graph-editor --> al-graph-settings
   al-graph-editor --> al-node-list
   al-graph-editor --> ion-item-divider
   al-graph-editor --> al-node-editor
   al-graph-editor --> al-edge-editor
   al-graph-editor --> al-angle-editor
-  al-node-list --> ion-list
-  al-node-list --> ion-item
+  al-graph-settings --> ion-item
+  al-graph-settings --> ion-toggle
   ion-item --> ion-icon
   ion-item --> ion-ripple-effect
+  al-node-list --> ion-list
+  al-node-list --> ion-item
   al-node-editor --> ion-item
   al-node-editor --> ion-input
   al-node-editor --> ion-textarea

--- a/src/components/al-graph-settings/ContentStrings.ts
+++ b/src/components/al-graph-settings/ContentStrings.ts
@@ -1,0 +1,31 @@
+import { I18nJson } from "../../interfaces/I18nJson";
+
+export interface ContentStrings extends I18nJson {
+  axial?: string;
+  boundingBoxEnabled?: string;
+  brightness?: string;
+  clay?: string;
+  contrast?: string;
+  controlsType?: string;
+  coronal?: string;
+  default?: string;
+  displayMode?: string;
+  graphEnabled?: string;
+  material?: string;
+  meters?: string;
+  millimeters?: string;
+  normals?: string;
+  orbit?: string;
+  orientation?: string;
+  recenter?: string;
+  saggital?: string;
+  sliceIndex?: string;
+  slices?: string;
+  trackball?: string;
+  units?: string;
+  volume?: string;
+  volumeSteps?: string;
+  volumeStepsHighEnabled?: string;
+  wireframe?: string;
+  xray?: string;
+}

--- a/src/components/al-graph-settings/al-graph-settings.css
+++ b/src/components/al-graph-settings/al-graph-settings.css
@@ -1,0 +1,31 @@
+/**
+ * @prop --display-mode-display: Display Mode Toggle Display
+ * @prop --graph-enabled-display: Graph Enabled Toggle Display
+ * @prop --bounding-box-enabled-display: Bounding Box Enabled Toggle Display
+ * @prop --slices-index-display: Slices Index Range Display
+ * @prop --slices-orientation-display: Slices Orientation Select Display
+ * @prop --slices-window-center-display: Slices Window Center Range Display
+ * @prop --slices-window-width-display: Slices Window Width Range Display
+ * @prop --volume-steps-display: Volume Steps Range Display
+ * @prop --volume-window-center-display: Volume Window Center Range Display
+ * @prop --volume-window-width-display: Volume Window Width Range Display
+ */
+
+select {
+  padding: 5px;
+  min-width: 100px;
+  background-color: var(--al-select-background-color);
+  color: var(--al-item-color);
+  border: none;
+}
+
+@supports (-moz-appearance: none) {
+  select {
+    background-color: #ffffff !important;
+    color: #000000 !important;
+  }
+}
+
+ion-label {
+  color: var(--al-item-color);
+}

--- a/src/components/al-graph-settings/al-graph-settings.i18n.en.json
+++ b/src/components/al-graph-settings/al-graph-settings.i18n.en.json
@@ -1,0 +1,6 @@
+{
+  "graphEnabled": "Enable Nodes",
+  "units": "Measurement Units",
+  "meters": "Meters",
+  "millimeters": "Millimeters"
+}

--- a/src/components/al-graph-settings/al-graph-settings.tsx
+++ b/src/components/al-graph-settings/al-graph-settings.tsx
@@ -1,0 +1,96 @@
+import { Component, Event, EventEmitter, h, Prop } from "@stencil/core";
+import { Units } from "../../enums";
+import i18n from "./al-graph-settings.i18n.en.json";
+import { ContentStrings } from "./ContentStrings";
+
+@Component({
+  tag: "al-graph-settings",
+  styleUrl: "al-graph-settings.css",
+  shadow: true
+})
+export class AlSettings {
+  private _contentStrings: ContentStrings = i18n;
+
+  @Event() public unitsChanged: EventEmitter;
+  @Event() public graphEnabledChanged: EventEmitter;
+
+  @Prop({ mutable: true }) public graphEnabled: boolean;
+  @Prop({ mutable: true }) public graphVisible: boolean;
+  @Prop({ mutable: true }) public units: Units;
+
+  private _graphEnabled(enabled: boolean) {
+    this.graphEnabled = enabled;
+    this.graphEnabledChanged.emit(enabled);
+  }
+
+  private _units(units: Units) {
+    this.units = units;
+    this.unitsChanged.emit(this.units);
+  }
+
+  public renderGraphEnabled() {
+    if (this.graphVisible) {
+      return (
+        <div>
+          <ion-item
+            style={{
+              display: "var(--graph-enabled-display, block)"
+            }}
+          >
+            <span title={this._contentStrings.graphEnabled}>
+              {this._contentStrings.graphEnabled}
+            </span>
+            <ion-toggle
+              slot="end"
+              checked={this.graphEnabled}
+              onIonChange={e => this._graphEnabled(e.detail.checked)}
+            />
+          </ion-item>
+          <ion-item
+            style={{
+              display: "var(--units-display, block)"
+            }}
+          >
+            <span title={this._contentStrings.units}>
+              {this._contentStrings.units}
+            </span>
+            <select
+              slot="end"
+              onChange={e =>
+                this._units((e.srcElement as HTMLSelectElement).value as Units)
+              }
+            >
+              <option
+                selected={this.units === Units.MILLIMETERS}
+                value={Units.MILLIMETERS}
+              >
+                {this._contentStrings.millimeters}
+              </option>
+              <option
+                selected={this.units === Units.METERS}
+                value={Units.METERS}
+              >
+                {this._contentStrings.meters}
+              </option>
+            </select>
+          </ion-item>
+        </div>
+      );
+    } else {
+      return <span>hello world</span>;
+    }
+  }
+
+  public render() {
+    return (
+      <div
+        style={{
+          "max-width": "100%",
+          "overflow-x": "hidden"
+        }}
+      >
+        {this.renderGraphEnabled()}
+      </div>
+    );
+  }
+}

--- a/src/components/al-graph-settings/readme.md
+++ b/src/components/al-graph-settings/readme.md
@@ -1,0 +1,65 @@
+# al-graph-settings
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property       | Attribute       | Description | Type                                | Default     |
+| -------------- | --------------- | ----------- | ----------------------------------- | ----------- |
+| `graphEnabled` | `graph-enabled` |             | `boolean`                           | `undefined` |
+| `graphVisible` | `graph-visible` |             | `boolean`                           | `undefined` |
+| `units`        | `units`         |             | `Units.METERS \| Units.MILLIMETERS` | `undefined` |
+
+
+## Events
+
+| Event                 | Description | Type               |
+| --------------------- | ----------- | ------------------ |
+| `graphEnabledChanged` |             | `CustomEvent<any>` |
+| `unitsChanged`        |             | `CustomEvent<any>` |
+
+
+## CSS Custom Properties
+
+| Name                             | Description                         |
+| -------------------------------- | ----------------------------------- |
+| `--bounding-box-enabled-display` | Bounding Box Enabled Toggle Display |
+| `--display-mode-display`         | Display Mode Toggle Display         |
+| `--graph-enabled-display`        | Graph Enabled Toggle Display        |
+| `--slices-index-display`         | Slices Index Range Display          |
+| `--slices-orientation-display`   | Slices Orientation Select Display   |
+| `--slices-window-center-display` | Slices Window Center Range Display  |
+| `--slices-window-width-display`  | Slices Window Width Range Display   |
+| `--volume-steps-display`         | Volume Steps Range Display          |
+| `--volume-window-center-display` | Volume Window Center Range Display  |
+| `--volume-window-width-display`  | Volume Window Width Range Display   |
+
+
+## Dependencies
+
+### Used by
+
+ - [al-graph-editor](../al-graph-editor)
+
+### Depends on
+
+- ion-item
+- ion-toggle
+
+### Graph
+```mermaid
+graph TD;
+  al-graph-settings --> ion-item
+  al-graph-settings --> ion-toggle
+  ion-item --> ion-icon
+  ion-item --> ion-ripple-effect
+  al-graph-editor --> al-graph-settings
+  style al-graph-settings fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/al-node-editor/readme.md
+++ b/src/components/al-node-editor/readme.md
@@ -24,7 +24,7 @@
 
 ### Used by
 
- - [al-graph-editor](..\al-graph-editor)
+ - [al-graph-editor](../al-graph-editor)
 
 ### Depends on
 

--- a/src/components/al-node-list/al-node-list.i18n.en.json
+++ b/src/components/al-node-list/al-node-list.i18n.en.json
@@ -1,3 +1,3 @@
 {
-  "graphEmpty": "The graph is currently empty"
+  "graphEmpty": "No nodes have been placed."
 }

--- a/src/components/al-node-list/al-node-list.tsx
+++ b/src/components/al-node-list/al-node-list.tsx
@@ -19,7 +19,15 @@ export class AlNodeList {
   public render() {
     if (this.nodes && this.nodes.size) {
       return (
-        <ion-list>
+        <ion-list
+          style={{
+            color: "var(--al-item-color)",
+            "border-width": "1px 0 0 0",
+            "border-color": "var(--ion-list-header-border-color)",
+            "border-style": "solid",
+            "margin-top": "10px"
+          }}
+        >
           {Array.from(this.nodes).map(([nodeId, node]) => {
             return (
               <ion-item
@@ -34,7 +42,15 @@ export class AlNodeList {
       );
     }
     return (
-      <ion-item>
+      <ion-item
+        style={{
+          color: "var(--al-item-color)",
+          "border-width": "1px 0 0 0",
+          "border-color": "var(--ion-list-header-border-color)",
+          "border-style": "solid",
+          "margin-top": "10px"
+        }}
+      >
         <p>{this._contentStrings.graphEmpty}</p>
       </ion-item>
     );

--- a/src/components/al-node-list/readme.md
+++ b/src/components/al-node-list/readme.md
@@ -24,7 +24,7 @@
 
 ### Used by
 
- - [al-graph-editor](..\al-graph-editor)
+ - [al-graph-editor](../al-graph-editor)
 
 ### Depends on
 

--- a/src/components/al-settings/al-settings.tsx
+++ b/src/components/al-settings/al-settings.tsx
@@ -1,11 +1,6 @@
 import { Component, Event, EventEmitter, h, Prop } from "@stencil/core";
 import AlertIcon from "../../assets/svg/alert.svg";
-import BoundingBoxIcon from "../../assets/svg/bounding-box-2.svg";
-import ObjectIcon from "../../assets/svg/object-alone.svg";
-import OrbitCameraIcon from "../../assets/svg/orbit_camera.svg";
-import RecenterIcon from "../../assets/svg/recenter.svg";
-import RotateObjectIcon from "../../assets/svg/rotate_object.svg";
-import { ControlsType, Orientation, Units } from "../../enums";
+import { Orientation } from "../../enums";
 import { DisplayMode } from "../../enums/DisplayMode";
 import i18n from "./al-settings.i18n.en.json";
 import { ContentStrings } from "./ContentStrings";
@@ -18,63 +13,31 @@ import { ContentStrings } from "./ContentStrings";
 export class AlSettings {
   private _contentStrings: ContentStrings = i18n;
 
-  @Event() public boundingBoxEnabledChanged: EventEmitter;
-  @Event() public controlsTypeChanged: EventEmitter;
   @Event() public displayModeChanged: EventEmitter;
-  // @Event() public materialChanged: EventEmitter;
   @Event() public orientationChanged: EventEmitter;
-  @Event() public recenter: EventEmitter;
   @Event() public slicesIndexChanged: EventEmitter;
   @Event() public slicesBrightnessChanged: EventEmitter;
   @Event() public slicesContrastChanged: EventEmitter;
-  @Event() public unitsChanged: EventEmitter;
-  @Event() public graphEnabledChanged: EventEmitter;
   @Event() public volumeBrightnessChanged: EventEmitter;
   @Event() public volumeContrastChanged: EventEmitter;
   @Event() public volumeStepsChanged: EventEmitter;
   @Event() public volumeStepsHighEnabledChanged: EventEmitter;
 
-  @Prop({ mutable: true }) public boundingBoxEnabled: boolean;
-  @Prop({ mutable: true }) public controlsType: ControlsType;
   @Prop({ mutable: true }) public displayMode: DisplayMode;
-  @Prop({ mutable: true }) public graphEnabled: boolean;
-  @Prop({ mutable: true }) public graphVisible: boolean;
-  // @Prop({ mutable: true }) public material: Material = Material.DEFAULT;
   @Prop({ mutable: true }) public orientation: Orientation;
   @Prop({ mutable: true }) public slicesIndex: number;
   @Prop({ mutable: true }) public slicesMaxIndex: number;
   @Prop({ mutable: true }) public slicesBrightness: number; // window center
   @Prop({ mutable: true }) public slicesContrast: number; // window width
-  @Prop({ mutable: true }) public units: Units;
   @Prop({ mutable: true }) public volumeBrightness: number; // window center
   @Prop({ mutable: true }) public volumeContrast: number; // window width
   @Prop({ mutable: true }) public volumeSteps: number;
   @Prop({ mutable: true }) public volumeStepsHighEnabled: boolean;
 
-  private _boundingBoxEnabled(enabled: boolean) {
-    this.boundingBoxEnabled = enabled;
-    this.boundingBoxEnabledChanged.emit(enabled);
-  }
-
-  private _controlsType(controlsType: ControlsType) {
-    this.controlsType = controlsType;
-    this.controlsTypeChanged.emit(controlsType);
-  }
-
   private _displayMode(displayMode: DisplayMode) {
     this.displayMode = displayMode;
     this.displayModeChanged.emit(displayMode);
   }
-
-  private _graphEnabled(enabled: boolean) {
-    this.graphEnabled = enabled;
-    this.graphEnabledChanged.emit(enabled);
-  }
-
-  // private _material(material: Material) {
-  //   this.material = material;
-  //   this.materialChanged.emit(material);
-  // }
 
   private _orientation(orientation: Orientation) {
     this.orientation = orientation;
@@ -94,27 +57,6 @@ export class AlSettings {
   private _slicesContrast(contrast: number) {
     this.slicesContrast = contrast;
     this.slicesContrastChanged.emit(contrast);
-  }
-
-  private _switchBoundingBoxEnabled() {
-    if (this.boundingBoxEnabled) {
-      this._boundingBoxEnabled(false);
-    } else {
-      this._boundingBoxEnabled(true);
-    }
-  }
-
-  private _switchControls() {
-    if (this.controlsType === ControlsType.ORBIT) {
-      this._controlsType(ControlsType.TRACKBALL);
-    } else if (this.controlsType === ControlsType.TRACKBALL) {
-      this._controlsType(ControlsType.ORBIT);
-    }
-  }
-
-  private _units(units: Units) {
-    this.units = units;
-    this.unitsChanged.emit(this.units);
   }
 
   private _volumeBrightness(brightness: number) {
@@ -139,131 +81,6 @@ export class AlSettings {
     } else {
       this._volumeSteps(this.volumeSteps - 0.2);
     }
-  }
-
-  public renderControlsTypeSelect() {
-    let cameraIcon: string;
-    let cameraLabel: string;
-    if (this.controlsType === ControlsType.ORBIT) {
-      cameraIcon = OrbitCameraIcon;
-      cameraLabel = this._contentStrings.orbit;
-    } else if (this.controlsType === ControlsType.TRACKBALL) {
-      cameraIcon = RotateObjectIcon;
-      cameraLabel = this._contentStrings.rotate;
-    }
-    let boundingBoxEnabledIcon: string;
-    if (this.boundingBoxEnabled) {
-      boundingBoxEnabledIcon = BoundingBoxIcon;
-    } else {
-      boundingBoxEnabledIcon = ObjectIcon;
-    }
-    return (
-      <div
-        style={{
-          "margin-top": "10px",
-          "text-align": "center"
-        }}
-      >
-        <ion-button
-          style={{
-            width: "28%",
-            height: "45px",
-            "margin-left": "5px",
-            "margin-right": "5px"
-          }}
-          size="small"
-          onClick={() => {
-            this._switchControls();
-          }}
-        >
-          <div
-            style={{
-              "font-size": "10px",
-              color: "white",
-              "margin-bottom": "2px"
-            }}
-          >
-            <ion-icon
-              style={{
-                "min-width": "20px",
-                "min-height": "20px",
-                "margin-bottom": "2px"
-              }}
-              src={cameraIcon}
-              title={cameraLabel}
-            />
-            <br />
-            {cameraLabel}
-          </div>
-        </ion-button>
-
-        <ion-button
-          style={{
-            width: "28%",
-            height: "45px",
-            "margin-left": "5px",
-            "margin-right": "5px"
-          }}
-          size="small"
-          onClick={() => {
-            this.recenter.emit();
-          }}
-        >
-          <div
-            style={{
-              "font-size": "10px",
-              color: "white",
-              "margin-bottom": "2px"
-            }}
-          >
-            <ion-icon
-              style={{
-                "min-width": "20px",
-                "min-height": "20px",
-                "margin-bottom": "2px"
-              }}
-              src={RecenterIcon}
-              title={this._contentStrings.recenter}
-            />
-            <br />
-            {this._contentStrings.recenter}
-          </div>
-        </ion-button>
-
-        <ion-button
-          style={{
-            width: "28%",
-            height: "45px",
-            "margin-left": "5px",
-            "margin-right": "5px"
-          }}
-          size="small"
-          onClick={() => {
-            this._switchBoundingBoxEnabled();
-          }}
-        >
-          <div
-            style={{
-              "font-size": "10px",
-              color: "white",
-              "margin-bottom": "2px"
-            }}
-          >
-            <ion-icon
-              style={{
-                "min-width": "20px",
-                "min-height": "20px",
-                "margin-bottom": "2px"
-              }}
-              src={boundingBoxEnabledIcon}
-              title={this._contentStrings.bounds}
-            />
-            <br />
-            {this._contentStrings.bounds}
-          </div>
-        </ion-button>
-      </div>
-    );
   }
 
   public renderDisplayModeToggle() {
@@ -301,68 +118,6 @@ export class AlSettings {
     }
 
     return null;
-  }
-
-  public renderGraphEnabled() {
-    if (this.graphVisible) {
-      return (
-        <div>
-          <ion-list-header
-            style={{
-              color: "var(--al-item-color)",
-              "border-width": "1px 0 0 0",
-              "border-color": "var(--ion-list-header-border-color)",
-              "border-style": "solid",
-              "margin-top": "10px"
-            }}
-          >
-            <span>Measure and Annotate</span>
-          </ion-list-header>
-          <ion-item
-            style={{
-              display: "var(--graph-enabled-display, block)"
-            }}
-          >
-            <span title={this._contentStrings.graphEnabled}>
-              {this._contentStrings.graphEnabled}
-            </span>
-            <ion-toggle
-              slot="end"
-              checked={this.graphEnabled}
-              onIonChange={e => this._graphEnabled(e.detail.checked)}
-            />
-          </ion-item>
-          <ion-item
-            style={{
-              display: "var(--units-display, block)"
-            }}
-          >
-            <span title={this._contentStrings.units}>Units</span>
-            <select
-              slot="end"
-              onChange={e =>
-                this._units((e.srcElement as HTMLSelectElement).value as Units)
-              }
-            >
-              <option
-                selected={this.units === Units.MILLIMETERS}
-                value={Units.MILLIMETERS}
-              >
-                {this._contentStrings.millimeters}
-              </option>
-              <option
-                selected={this.units === Units.METERS}
-                value={Units.METERS}
-              >
-                {this._contentStrings.meters}
-              </option>
-            </select>
-          </ion-item>
-        </div>
-      );
-    } else {
-      return null;
-    }
   }
 
   public renderHiResEnabled() {
@@ -580,10 +335,8 @@ export class AlSettings {
           "overflow-x": "hidden"
         }}
       >
-        {this.renderControlsTypeSelect()}
         {this.renderDisplayModeToggle()}
         {this.renderOptions()}
-        {this.renderGraphEnabled()}
       </div>
     );
   }

--- a/src/components/al-settings/readme.md
+++ b/src/components/al-settings/readme.md
@@ -9,17 +9,12 @@
 
 | Property                 | Attribute                   | Description | Type                                                               | Default     |
 | ------------------------ | --------------------------- | ----------- | ------------------------------------------------------------------ | ----------- |
-| `boundingBoxEnabled`     | `bounding-box-enabled`      |             | `boolean`                                                          | `undefined` |
-| `controlsType`           | `controls-type`             |             | `ControlsType.ORBIT \| ControlsType.TRACKBALL`                     | `undefined` |
 | `displayMode`            | `display-mode`              |             | `DisplayMode.MESH \| DisplayMode.SLICES \| DisplayMode.VOLUME`     | `undefined` |
-| `graphEnabled`           | `graph-enabled`             |             | `boolean`                                                          | `undefined` |
-| `graphVisible`           | `graph-visible`             |             | `boolean`                                                          | `undefined` |
 | `orientation`            | `orientation`               |             | `Orientation.AXIAL \| Orientation.CORONAL \| Orientation.SAGGITAL` | `undefined` |
 | `slicesBrightness`       | `slices-brightness`         |             | `number`                                                           | `undefined` |
 | `slicesContrast`         | `slices-contrast`           |             | `number`                                                           | `undefined` |
 | `slicesIndex`            | `slices-index`              |             | `number`                                                           | `undefined` |
 | `slicesMaxIndex`         | `slices-max-index`          |             | `number`                                                           | `undefined` |
-| `units`                  | `units`                     |             | `Units.METERS \| Units.MILLIMETERS`                                | `undefined` |
 | `volumeBrightness`       | `volume-brightness`         |             | `number`                                                           | `undefined` |
 | `volumeContrast`         | `volume-contrast`           |             | `number`                                                           | `undefined` |
 | `volumeSteps`            | `volume-steps`              |             | `number`                                                           | `undefined` |
@@ -30,16 +25,11 @@
 
 | Event                           | Description | Type               |
 | ------------------------------- | ----------- | ------------------ |
-| `boundingBoxEnabledChanged`     |             | `CustomEvent<any>` |
-| `controlsTypeChanged`           |             | `CustomEvent<any>` |
 | `displayModeChanged`            |             | `CustomEvent<any>` |
-| `graphEnabledChanged`           |             | `CustomEvent<any>` |
 | `orientationChanged`            |             | `CustomEvent<any>` |
-| `recenter`                      |             | `CustomEvent<any>` |
 | `slicesBrightnessChanged`       |             | `CustomEvent<any>` |
 | `slicesContrastChanged`         |             | `CustomEvent<any>` |
 | `slicesIndexChanged`            |             | `CustomEvent<any>` |
-| `unitsChanged`                  |             | `CustomEvent<any>` |
 | `volumeBrightnessChanged`       |             | `CustomEvent<any>` |
 | `volumeContrastChanged`         |             | `CustomEvent<any>` |
 | `volumeStepsChanged`            |             | `CustomEvent<any>` |
@@ -66,27 +56,24 @@
 
 ### Used by
 
- - [al-control-panel](..\al-control-panel)
+ - [al-control-panel](../al-control-panel)
 
 ### Depends on
 
-- ion-button
-- ion-icon
 - ion-item
-- ion-list-header
+- ion-icon
 - ion-toggle
 - ion-range
+- ion-list-header
 
 ### Graph
 ```mermaid
 graph TD;
-  al-settings --> ion-button
-  al-settings --> ion-icon
   al-settings --> ion-item
-  al-settings --> ion-list-header
+  al-settings --> ion-icon
   al-settings --> ion-toggle
   al-settings --> ion-range
-  ion-button --> ion-ripple-effect
+  al-settings --> ion-list-header
   ion-item --> ion-icon
   ion-item --> ion-ripple-effect
   al-control-panel --> al-settings

--- a/src/components/al-tabs/readme.md
+++ b/src/components/al-tabs/readme.md
@@ -59,7 +59,7 @@ Type: `Promise<boolean>`
 
 ### Used by
 
- - [al-control-panel](..\al-control-panel)
+ - [al-control-panel](../al-control-panel)
 
 ### Graph
 ```mermaid

--- a/src/components/al-url-picker/readme.md
+++ b/src/components/al-url-picker/readme.md
@@ -24,7 +24,7 @@
 
 ### Used by
 
- - [al-control-panel](..\al-control-panel)
+ - [al-control-panel](../al-control-panel)
 
 ### Depends on
 

--- a/src/components/al-view-controls/ContentStrings.ts
+++ b/src/components/al-view-controls/ContentStrings.ts
@@ -1,0 +1,11 @@
+import { I18nJson } from "../../interfaces/I18nJson";
+
+export interface ContentStrings extends I18nJson {
+  boundingBoxEnabled?: string;
+  controlsType?: string;
+  default?: string;
+  graphEnabled?: string;
+  orbit?: string;
+  recenter?: string;
+  trackball?: string;
+}

--- a/src/components/al-view-controls/al-view-controls.css
+++ b/src/components/al-view-controls/al-view-controls.css
@@ -1,0 +1,31 @@
+/**
+ * @prop --display-mode-display: Display Mode Toggle Display
+ * @prop --graph-enabled-display: Graph Enabled Toggle Display
+ * @prop --bounding-box-enabled-display: Bounding Box Enabled Toggle Display
+ * @prop --slices-index-display: Slices Index Range Display
+ * @prop --slices-orientation-display: Slices Orientation Select Display
+ * @prop --slices-window-center-display: Slices Window Center Range Display
+ * @prop --slices-window-width-display: Slices Window Width Range Display
+ * @prop --volume-steps-display: Volume Steps Range Display
+ * @prop --volume-window-center-display: Volume Window Center Range Display
+ * @prop --volume-window-width-display: Volume Window Width Range Display
+ */
+
+select {
+  padding: 5px;
+  min-width: 100px;
+  background-color: var(--al-select-background-color);
+  color: var(--al-item-color);
+  border: none;
+}
+
+@supports (-moz-appearance: none) {
+  select {
+    background-color: #ffffff !important;
+    color: #000000 !important;
+  }
+}
+
+ion-label {
+  color: var(--al-item-color);
+}

--- a/src/components/al-view-controls/al-view-controls.i18n.en.json
+++ b/src/components/al-view-controls/al-view-controls.i18n.en.json
@@ -11,6 +11,8 @@
   "displayMode": "Display Mode",
   "graphEnabled": "Enable Node Placement",
   "material": "Material",
+  "meters": "Meters",
+  "millimeters": "Millimeters",
   "normals": "Normals",
   "orbit": "Orbit",
   "orientation": "Orientation",

--- a/src/components/al-view-controls/al-view-controls.tsx
+++ b/src/components/al-view-controls/al-view-controls.tsx
@@ -1,0 +1,194 @@
+import { Component, Event, EventEmitter, h, Prop } from "@stencil/core";
+import BoundingBoxIcon from "../../assets/svg/bounding-box-2.svg";
+import ObjectIcon from "../../assets/svg/object-alone.svg";
+import OrbitCameraIcon from "../../assets/svg/orbit_camera.svg";
+import RecenterIcon from "../../assets/svg/recenter.svg";
+import RotateObjectIcon from "../../assets/svg/rotate_object.svg";
+import { ControlsType } from "../../enums";
+import i18n from "./al-view-controls.i18n.en.json";
+import { ContentStrings } from "./ContentStrings";
+
+@Component({
+  tag: "al-view-controls",
+  styleUrl: "al-view-controls.css",
+  shadow: true
+})
+export class AlSettings {
+  private _contentStrings: ContentStrings = i18n;
+
+  @Event() public boundingBoxEnabledChanged: EventEmitter;
+  @Event() public controlsTypeChanged: EventEmitter;
+  @Event() public recenter: EventEmitter;
+
+  @Prop({ mutable: true }) public boundingBoxEnabled: boolean;
+  @Prop({ mutable: true }) public controlsType: ControlsType;
+
+  private _boundingBoxEnabled(enabled: boolean) {
+    this.boundingBoxEnabled = enabled;
+    this.boundingBoxEnabledChanged.emit(enabled);
+  }
+
+  private _controlsType(controlsType: ControlsType) {
+    this.controlsType = controlsType;
+    this.controlsTypeChanged.emit(controlsType);
+  }
+
+  private _switchBoundingBoxEnabled() {
+    if (this.boundingBoxEnabled) {
+      this._boundingBoxEnabled(false);
+    } else {
+      this._boundingBoxEnabled(true);
+    }
+  }
+
+  private _switchControls() {
+    if (this.controlsType === ControlsType.ORBIT) {
+      this._controlsType(ControlsType.TRACKBALL);
+    } else if (this.controlsType === ControlsType.TRACKBALL) {
+      this._controlsType(ControlsType.ORBIT);
+    }
+  }
+
+  public renderControlsTypeSelect() {
+    let cameraIcon: string;
+    let cameraLabel: string;
+    if (this.controlsType === ControlsType.ORBIT) {
+      cameraIcon = OrbitCameraIcon;
+      cameraLabel = this._contentStrings.orbit;
+    } else if (this.controlsType === ControlsType.TRACKBALL) {
+      cameraIcon = RotateObjectIcon;
+      cameraLabel = this._contentStrings.rotate;
+    }
+    let boundingBoxEnabledIcon: string;
+    if (this.boundingBoxEnabled) {
+      boundingBoxEnabledIcon = BoundingBoxIcon;
+    } else {
+      boundingBoxEnabledIcon = ObjectIcon;
+    }
+    return (
+      <div
+        style={{
+          "margin-top": "10px",
+          "text-align": "center"
+        }}
+      >
+        <ion-button
+          style={{
+            width: "28%",
+            height: "45px",
+            "margin-left": "5px",
+            "margin-right": "5px"
+          }}
+          size="small"
+          onClick={() => {
+            this._switchControls();
+          }}
+        >
+          <div
+            style={{
+              "font-size": "10px",
+              color: "white",
+              "margin-bottom": "2px"
+            }}
+          >
+            <ion-icon
+              style={{
+                "min-width": "20px",
+                "min-height": "20px",
+                "margin-bottom": "2px"
+              }}
+              src={cameraIcon}
+              title={cameraLabel}
+            />
+            <br />
+            {cameraLabel}
+          </div>
+        </ion-button>
+
+        <ion-button
+          style={{
+            width: "28%",
+            height: "45px",
+            "margin-left": "5px",
+            "margin-right": "5px"
+          }}
+          size="small"
+          onClick={() => {
+            this.recenter.emit();
+          }}
+        >
+          <div
+            style={{
+              "font-size": "10px",
+              color: "white",
+              "margin-bottom": "2px"
+            }}
+          >
+            <ion-icon
+              style={{
+                "min-width": "20px",
+                "min-height": "20px",
+                "margin-bottom": "2px"
+              }}
+              src={RecenterIcon}
+              title={this._contentStrings.recenter}
+            />
+            <br />
+            {this._contentStrings.recenter}
+          </div>
+        </ion-button>
+
+        <ion-button
+          style={{
+            width: "28%",
+            height: "45px",
+            "margin-left": "5px",
+            "margin-right": "5px"
+          }}
+          size="small"
+          onClick={() => {
+            this._switchBoundingBoxEnabled();
+          }}
+        >
+          <div
+            style={{
+              "font-size": "10px",
+              color: "white",
+              "margin-bottom": "2px"
+            }}
+          >
+            <ion-icon
+              style={{
+                "min-width": "20px",
+                "min-height": "20px",
+                "margin-bottom": "2px"
+              }}
+              src={boundingBoxEnabledIcon}
+              title={this._contentStrings.bounds}
+            />
+            <br />
+            {this._contentStrings.bounds}
+          </div>
+        </ion-button>
+      </div>
+    );
+  }
+
+  public render() {
+    return (
+      <div
+        style={{
+          "max-width": "100%",
+          "overflow-x": "hidden",
+          "border-width": "0 0 1px 0",
+          "border-color": "var(--ion-list-header-border-color)",
+          "border-style": "solid",
+          "padding-bottom": "10px",
+          "margin-bottom": "10px"
+        }}
+      >
+        {this.renderControlsTypeSelect()}
+      </div>
+    );
+  }
+}

--- a/src/components/al-view-controls/readme.md
+++ b/src/components/al-view-controls/readme.md
@@ -1,0 +1,64 @@
+# al-view-controls
+
+
+
+<!-- Auto Generated Below -->
+
+
+## Properties
+
+| Property             | Attribute              | Description | Type                                           | Default     |
+| -------------------- | ---------------------- | ----------- | ---------------------------------------------- | ----------- |
+| `boundingBoxEnabled` | `bounding-box-enabled` |             | `boolean`                                      | `undefined` |
+| `controlsType`       | `controls-type`        |             | `ControlsType.ORBIT \| ControlsType.TRACKBALL` | `undefined` |
+
+
+## Events
+
+| Event                       | Description | Type               |
+| --------------------------- | ----------- | ------------------ |
+| `boundingBoxEnabledChanged` |             | `CustomEvent<any>` |
+| `controlsTypeChanged`       |             | `CustomEvent<any>` |
+| `recenter`                  |             | `CustomEvent<any>` |
+
+
+## CSS Custom Properties
+
+| Name                             | Description                         |
+| -------------------------------- | ----------------------------------- |
+| `--bounding-box-enabled-display` | Bounding Box Enabled Toggle Display |
+| `--display-mode-display`         | Display Mode Toggle Display         |
+| `--graph-enabled-display`        | Graph Enabled Toggle Display        |
+| `--slices-index-display`         | Slices Index Range Display          |
+| `--slices-orientation-display`   | Slices Orientation Select Display   |
+| `--slices-window-center-display` | Slices Window Center Range Display  |
+| `--slices-window-width-display`  | Slices Window Width Range Display   |
+| `--volume-steps-display`         | Volume Steps Range Display          |
+| `--volume-window-center-display` | Volume Window Center Range Display  |
+| `--volume-window-width-display`  | Volume Window Width Range Display   |
+
+
+## Dependencies
+
+### Used by
+
+ - [al-control-panel](../al-control-panel)
+
+### Depends on
+
+- ion-button
+- ion-icon
+
+### Graph
+```mermaid
+graph TD;
+  al-view-controls --> ion-button
+  al-view-controls --> ion-icon
+  ion-button --> ion-ripple-effect
+  al-control-panel --> al-view-controls
+  style al-view-controls fill:#f9f,stroke:#333,stroke-width:4px
+```
+
+----------------------------------------------
+
+*Built with [StencilJS](https://stenciljs.com/)*

--- a/src/components/al-viewer/al-viewer.tsx
+++ b/src/components/al-viewer/al-viewer.tsx
@@ -551,6 +551,7 @@ export class Aleph {
                   enabled={this.controlsEnabled}
                   far={Constants.camera.far}
                   fov={Constants.camera.fov}
+                  graphEnabled={this.graphEnabled}
                   near={Constants.camera.near}
                   panSpeed={Constants.camera.panSpeed}
                   rotateSpeed={Constants.camera.trackballRotateSpeed}
@@ -585,6 +586,7 @@ export class Aleph {
                   enabled={this.controlsEnabled}
                   far={Constants.camera.far}
                   fov={Constants.camera.fov}
+                  graphEnabled={this.graphEnabled}
                   maxPolarAngle={Constants.camera.maxPolarAngle}
                   minDistance={Constants.camera.minDistance}
                   minPolarAngle={Constants.camera.minPolarAngle}

--- a/src/functional-components/aframe/OrbitCamera.tsx
+++ b/src/functional-components/aframe/OrbitCamera.tsx
@@ -8,6 +8,7 @@ interface OrbitCameraProps extends FunctionalComponentProps {
   enabled: boolean;
   far: number;
   fov: number;
+  graphEnabled: boolean;
   maxPolarAngle: number;
   minDistance: number;
   minPolarAngle: number;
@@ -27,6 +28,7 @@ export const OrbitCamera: FunctionalComponent<OrbitCameraProps> = (
     enabled,
     far,
     fov,
+    graphEnabled,
     maxPolarAngle,
     minDistance,
     minPolarAngle,
@@ -36,31 +38,63 @@ export const OrbitCamera: FunctionalComponent<OrbitCameraProps> = (
     zoomSpeed
   },
   _children
-) => (
-  <a-camera
-    fov={fov}
-    near={near}
-    look-controls="enabled: false"
-    far={far}
-    id="mainCamera"
-    al-cursor="rayOrigin: mouse"
-    raycaster="objects: .collidable;"
-    al-orbit-control={`
-      minPolarAngle: ${minPolarAngle};
-      maxPolarAngle: ${maxPolarAngle};
-      minDistance: ${minDistance};
-      screenSpacePanning: true;
-      rotateSpeed: ${rotateSpeed};
-      zoomSpeed: ${zoomSpeed};
-      enableDamping: true;
-      dampingFactor: ${dampingFactor};
-      controlTarget: ${controlTarget};
-      controlPosition: ${controlPosition};
-      enabled: ${enabled};
-      animating: ${animating};
-      panSpeed: ${panSpeed}
-    `}
-    al-control-lights
-    ref={ref => cb(ref)}
-  />
-);
+) =>
+  (() => {
+    if (graphEnabled) {
+      return (
+        <a-camera
+          fov={fov}
+          near={near}
+          look-controls="enabled: false"
+          far={far}
+          id="mainCamera"
+          al-cursor="rayOrigin: mouse"
+          raycaster="objects: .collidable;"
+          al-orbit-control={`
+            minPolarAngle: ${minPolarAngle};
+            maxPolarAngle: ${maxPolarAngle};
+            minDistance: ${minDistance};
+            screenSpacePanning: true;
+            rotateSpeed: ${rotateSpeed};
+            zoomSpeed: ${zoomSpeed};
+            enableDamping: true;
+            dampingFactor: ${dampingFactor};
+            controlTarget: ${controlTarget};
+            controlPosition: ${controlPosition};
+            enabled: ${enabled};
+            animating: ${animating};
+            panSpeed: ${panSpeed}
+          `}
+          al-control-lights
+          ref={ref => cb(ref)}
+        />
+      );
+    } else {
+      return (
+        <a-camera
+          fov={fov}
+          near={near}
+          look-controls="enabled: false"
+          far={far}
+          id="mainCamera"
+          al-orbit-control={`
+            minPolarAngle: ${minPolarAngle};
+            maxPolarAngle: ${maxPolarAngle};
+            minDistance: ${minDistance};
+            screenSpacePanning: true;
+            rotateSpeed: ${rotateSpeed};
+            zoomSpeed: ${zoomSpeed};
+            enableDamping: true;
+            dampingFactor: ${dampingFactor};
+            controlTarget: ${controlTarget};
+            controlPosition: ${controlPosition};
+            enabled: ${enabled};
+            animating: ${animating};
+            panSpeed: ${panSpeed}
+          `}
+          al-control-lights
+          ref={ref => cb(ref)}
+        />
+      );
+    }
+  })();

--- a/src/functional-components/aframe/TrackballCamera.tsx
+++ b/src/functional-components/aframe/TrackballCamera.tsx
@@ -8,6 +8,7 @@ interface TrackballCameraProps extends FunctionalComponentProps {
   enabled: boolean;
   far: number;
   fov: number;
+  graphEnabled: boolean;
   near: number;
   panSpeed: number;
   rotateSpeed: number;
@@ -26,6 +27,7 @@ export const TrackballCamera: FunctionalComponent<TrackballCameraProps> = (
     enabled,
     far,
     fov,
+    graphEnabled,
     near,
     panSpeed,
     rotateSpeed,
@@ -34,30 +36,61 @@ export const TrackballCamera: FunctionalComponent<TrackballCameraProps> = (
     zoomSpeed
   },
   _children
-) => (
-  <a-camera
-    fov={fov}
-    near={near}
-    look-controls="enabled: false"
-    far={far}
-    id="mainCamera"
-    al-cursor="rayOrigin: mouse"
-    raycaster="objects: .collidable;"
-    al-trackball-control={`
-      screenLeft: ${0};
-      screenTop: ${0};
-      screenWidth: ${screenWidth};
-      screenHeight: ${screenHeight};
-      rotateSpeed: ${rotateSpeed};
-      zoomSpeed: ${zoomSpeed};
-      panSpeed: ${panSpeed};
-      dynamicDampingFactor: ${dampingFactor};
-      controlTarget: ${controlTarget};
-      controlPosition: ${controlPosition};
-      enabled: ${enabled};
-      animating: ${animating}
-    `}
-    al-control-lights
-    ref={ref => cb(ref)}
-  />
-);
+) =>
+  (() => {
+    if (graphEnabled) {
+      return (
+        <a-camera
+          fov={fov}
+          near={near}
+          look-controls="enabled: false"
+          far={far}
+          id="mainCamera"
+          al-cursor="rayOrigin: mouse"
+          raycaster="objects: .collidable;"
+          al-trackball-control={`
+            screenLeft: ${0};
+            screenTop: ${0};
+            screenWidth: ${screenWidth};
+            screenHeight: ${screenHeight};
+            rotateSpeed: ${rotateSpeed};
+            zoomSpeed: ${zoomSpeed};
+            panSpeed: ${panSpeed};
+            dynamicDampingFactor: ${dampingFactor};
+            controlTarget: ${controlTarget};
+            controlPosition: ${controlPosition};
+            enabled: ${enabled};
+            animating: ${animating}
+          `}
+          al-control-lights
+          ref={ref => cb(ref)}
+        />
+      );
+    } else {
+      return (
+        <a-camera
+          fov={fov}
+          near={near}
+          look-controls="enabled: false"
+          far={far}
+          id="mainCamera"
+          al-trackball-control={`
+            screenLeft: ${0};
+            screenTop: ${0};
+            screenWidth: ${screenWidth};
+            screenHeight: ${screenHeight};
+            rotateSpeed: ${rotateSpeed};
+            zoomSpeed: ${zoomSpeed};
+            panSpeed: ${panSpeed};
+            dynamicDampingFactor: ${dampingFactor};
+            controlTarget: ${controlTarget};
+            controlPosition: ${controlPosition};
+            enabled: ${enabled};
+            animating: ${animating}
+          `}
+          al-control-lights
+          ref={ref => cb(ref)}
+        />
+      );
+    }
+  })();


### PR DESCRIPTION
- Node settings have been moved to graph tab
- "Enable Node Placement" has been changed to "Enable Nodes" and "Units" has been changed to "Measurement Units"
- View controls (camera type, recenter, toggle bounding box) now appear in all tabs
- "Enable Nodes" triggers all node interactiveness - placement, hovering, etc. Because the raycaster was the cause of large mesh performance issues, this resolves #15 